### PR TITLE
Fix issue #5: Use hrtime to support nano time and improve performance

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,30 @@
 $ npm install koa-response-time
 ```
 
+## Usage
+
+Basic usage:
+
+    var Koa = require('koa');
+    var responseTime = require('koa-response-time');
+    var app = new Koa();
+
+    app.use(responseTime());
+
+If you need response high resolution in nano time, set `highResolution` option to `true`:
+
+    app.use(responseTime(highResolution: true));
+
+
+Sample response header with `highResolution = false` (default):
+
+    X-Response-Time: 153ms
+
+Sample response header with `highResolution = true`:
+
+    X-Response-Time: 153.812ms
+
+
 ## Note
 
   Best to `.use()` at the _top_ before any other middleware,

--- a/Readme.md
+++ b/Readme.md
@@ -13,27 +13,34 @@ $ npm install koa-response-time
 
 ## Usage
 
-Basic usage:
+  Basic usage:
 
-    var Koa = require('koa');
-    var responseTime = require('koa-response-time');
-    var app = new Koa();
+```js
+var Koa = require('koa');
+var responseTime = require('koa-response-time');
+var app = new Koa();
 
-    app.use(responseTime());
+app.use(responseTime());
+```
 
-If you need response high resolution in nano time, set `highResolution` option to `true`:
+  If you need response high resolution in nano time, set `hrtime` option to `true`:
 
-    app.use(responseTime(highResolution: true));
+```js
+app.use(responseTime(hrtime: true));
+```
 
 
-Sample response header with `highResolution = false` (default):
+  Sample response header with `hrtime = false` (default):
 
-    X-Response-Time: 153ms
+```
+X-Response-Time: 153ms
+```
 
-Sample response header with `highResolution = true`:
+  Sample response header with `hrtime = true`:
 
-    X-Response-Time: 153.812ms
-
+```
+X-Response-Time: 153.123581ms
+```
 
 ## Note
 

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ var responseTime = require('./');
 var Koa = require('koa');
 var app = new Koa();
 
-app.use(responseTime());
+app.use(responseTime({hrtime: true}));
 
 app.use(function (ctx, next){
   return next().then(function () {

--- a/index.js
+++ b/index.js
@@ -6,18 +6,18 @@ module.exports = responseTime;
 
 /**
  * Add X-Response-Time header field.
- * @param {Dictionary} options options dictionary. { highResolution }
+ * @param {Dictionary} options options dictionary. { hrtime }
  *
- *        highResolution: boolean.
- *          `true` to return time in nanoseconds.
- *          `false` to return time in milliseconds.
+ *        hrtime: boolean.
+ *          `true` to use time in nanoseconds.
+ *          `false` to use time in milliseconds.
  *          Default is `false` to keep back compatible.
  * @return {Function}
  * @api public
  */
 
 function responseTime(options) {
-  var highResolution = options && options.highResolution;
+  var hrtime = options && options.hrtime;
   return function responseTime(ctx, next){
     var start = process.hrtime();
     return next().then(function () {
@@ -25,9 +25,9 @@ function responseTime(options) {
 
       // Format to high resolution time with nano time
       delta = delta[0] * 1000 + delta[1]/1000000;
-      if (!highResolution) {
+      if (!hrtime) {
         // truncate to milliseconds.
-        delta = delta.toFixed(3);
+        delta = Math.round(delta);
       }
       ctx.set('X-Response-Time', delta + 'ms');
     });

--- a/index.js
+++ b/index.js
@@ -6,16 +6,29 @@ module.exports = responseTime;
 
 /**
  * Add X-Response-Time header field.
+ * @param {Dictionary} options options dictionary. { highResolution }
  *
+ *        highResolution: boolean.
+ *          `true` to return time in nanoseconds.
+ *          `false` to return time in milliseconds.
+ *          Default is `false` to keep back compatible.
  * @return {Function}
  * @api public
  */
 
-function responseTime() {
+function responseTime(options) {
+  var highResolution = options && options.highResolution;
   return function responseTime(ctx, next){
-    var start = Date.now();
+    var start = process.hrtime();
     return next().then(function () {
-      var delta = Math.ceil(Date.now() - start);
+      var delta = process.hrtime(start);
+
+      // Format to high resolution time with nano time
+      delta = delta[0] * 1000 + delta[1]/1000000;
+      if (!highResolution) {
+        // truncate to milliseconds.
+        delta = delta.toFixed(3);
+      }
       ctx.set('X-Response-Time', delta + 'ms');
     });
   }


### PR DESCRIPTION
Use hrtime to support nano time and improve performance.

A simple benchmark between `hrtime()` and `Date()`:

    const LOOPS = 1000000
    function foo() {
    }

    console.time('dt')
    for (let i=0; i<LOOPS; ++i) {
        const now = new Date()
        foo()
        const elapsed = new Date() - now
    }
    console.timeEnd('dt')

    console.time('hrtime')
    for (let i=0; i<LOOPS; ++i) {
        const now = process.hrtime()
        foo()
        const elapsed = process.hrtime(now)
    }
    console.timeEnd('hrtime')

Output:

    dt: 443.781ms
    hrtime: 139.637ms

`hrtime()` is 3 times faster than `Date()`.

