### PR TITLE
feat: Add custom header option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function responseTime(options) {
         // truncate to milliseconds.
         delta = Math.round(delta);
       }
-      ctx.set('X-Response-Time', delta + 'ms');
+      ctx.set((options && options.header) || 'X-Response-Time', delta + 'ms');
     });
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -27,4 +27,17 @@ describe('Test koa response time', () => {
       .expect('x-response-time', /^[0-9]{1,3}.[0-9]{3,6}ms$/)
       .expect(404);
   });
+
+  it('custom header name', () => {
+    const app = new Koa();
+
+    app.use(responseTime({
+      header: "Response-Time"
+    }));
+
+    return request(app.listen())
+      .get('/')
+      .expect('response-time', /^[0-9]{1,3}ms$/)
+      .expect(404);
+  });
 });


### PR DESCRIPTION
Prefing HTTP headers is [discouraged](https://tonyxu.io/posts/2018/http-deprecate-x-prefix/) by the IETF.
So this option gives users the option to call their header just "Response-Time".