### PR TITLE
Update to use process.hrtime.bigint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,3 @@
 extends: koa
+env:
+  es2020: true


### PR DESCRIPTION
Though `process.hrtime` is only marked as legacy and will likely not be removed, there are no guarantees and it is not being actively maintained.
This PR updates this middleware to use `process.hrtime.bigint` as it is the currently recommended way of handling timing.
