### PR TITLE
Updated jsdocs to be more descriptive

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
 
-let responseTime = require('./');
-let Koa = require('koa');
-let app = new Koa();
+const responseTime = require('./');
+const Koa = require('koa');
+const app = new Koa();
 
 app.use(responseTime({ hrtime: true }));
 

--- a/index.js
+++ b/index.js
@@ -4,25 +4,30 @@
 
 module.exports = responseTime;
 
+const defaultProps = { hrtime: false };
+
 /**
- * Add X-Response-Time header field.
- * @param {Dictionary} options options dictionary. { hrtime }
- *
- *        hrtime: boolean.
- *          `true` to use time in nanoseconds.
- *          `false` to use time in milliseconds.
- *          Default is `false` to keep back compatible.
- * @return {Function}
- * @api public
+ * @typedef {import("koa").Middleware} Middleware
  */
 
-function responseTime(options) {
-  let hrtime = options && options.hrtime;
+/**
+ * Add X-Response-Time header field.
+ * @param {Object} options options dictionary. { hrtime }
+ * @param {boolean} options.hrtime
+ *          - `true` to use time in nanoseconds.
+ *          - `false` to use time in milliseconds.
+ *          Default is `false` to keep back compatible.
+ * @return {Middleware} Koa Middleware
+ * @api public
+ */
+function responseTime(options = defaultProps) {
+  const hrtime = options && options.hrtime;
   return function responseTime(ctx, next) {
-    let start = ctx[Symbol.for('request-received.startAt')] ? ctx[Symbol.for('request-received.startAt')] : process.hrtime();
+    const start = ctx[Symbol.for('request-received.startAt')]
+      ? ctx[Symbol.for('request-received.startAt')]
+      : process.hrtime();
     return next().then(() => {
       let delta = process.hrtime(start);
-
       // Format to high resolution time with nano time
       delta = delta[0] * 1000 + delta[1] / 1000000;
       if (!hrtime) {


### PR DESCRIPTION
The current jsdocs aren't descriptive enough for typescript to understand that this middleware is compatible with Koa.
I've updated them to specify that `responseTime` returns a `Koa.Middleware` and to better describe the options object.
In addition I added a default parameter to indicate that `options` is optional.
